### PR TITLE
Skip printing table without rows

### DIFF
--- a/src/htmlRenderer.js
+++ b/src/htmlRenderer.js
@@ -185,6 +185,10 @@ export function renderImage({ command, styles }) {
 }
 
 export function renderTable({ command, state }) {
+  if (!command.attributes.rows) {
+    return '';
+  }
+
   let html = '<table class="rpml-table">';
 
   const contentClasses = buildContentClasses({ styles: state.styles });

--- a/src/printerEncoder.js
+++ b/src/printerEncoder.js
@@ -100,6 +100,9 @@ export function encodeCommand({ command, encoder, dots, images }) {
 
     case 'table':
       encoder = resetSize({ encoder });
+      if (!command.attributes.rows) {
+        return encoder;
+      }
       const table = buildTable({ command, width: encoder.columns });
       return encoder.table(table.columns, table.rows);
 

--- a/test/htmlRenderer.test.js
+++ b/test/htmlRenderer.test.js
@@ -300,6 +300,21 @@ describe('HTML Renderer', () => {
       expect(output).to.include('text-align: right');
       expect(output).to.include('&nbsp;'); // margin cell
     });
+
+    it('skips table without rows', () => {
+      const command = {
+        name: 'table',
+        attributes: {
+          cols: 2,
+          margin: 1,
+          align: ['left', 'right'],
+        },
+      };
+      const state = buildState();
+
+      const output = renderTable({ command, state });
+      expect(output).to.eq('');
+    });
   });
 
   describe('renderTableCell and renderTableCellMargin', () => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -278,6 +278,24 @@ describe('Parser', () => {
     ]);
   });
 
+  it('parses table tag with no rows', () => {
+    const markup = `{table
+        cols=2
+        margin=1
+      }`;
+    const output = parse(markup);
+
+    expect(output).to.deep.equal([
+      {
+        name: 'table',
+        attributes: {
+          cols: 2,
+          margin: 1,
+        },
+      },
+    ]);
+  });
+
   // Rule Tag
   it('parses rule tag correctly', () => {
     const markup = `{rule}`;

--- a/test/printerEncoder.test.js
+++ b/test/printerEncoder.test.js
@@ -271,6 +271,25 @@ This should still render`;
     expect(tableCommand).to.include('3x2'); // 3 columns, 2 rows
   });
 
+  it('skips table without rows', async () => {
+    const markup = `
+{table
+  cols=3
+  margin=1
+  align=[left,center,right]
+  width=[10,10,*]
+}`;
+
+    const encoder = await encodeReceipt({
+      commands: parse(markup),
+      encoder: new MockPrinterEncoder(),
+    });
+
+    const commands = encoder.commands;
+    const tableCommand = commands.find((cmd) => cmd.startsWith('table:'));
+    expect(tableCommand).to.not.exist;
+  });
+
   it('renders rules with different styles', async () => {
     const markup = `
 {rule line=solid width=32}


### PR DESCRIPTION
- Skip rendering table without rows in HTML
- Skip printing table without rows in printer encoder